### PR TITLE
fix: 🐛 corregir campo addons enviado como {} en lugar de [] al crear orden

### DIFF
--- a/src/core/services/checkoutService.ts
+++ b/src/core/services/checkoutService.ts
@@ -158,7 +158,7 @@ async function createRestaurantOrder(
         ? item.selectedAddons
             .filter(a => a.quantity > 0)
             .map(a => ({ name: a.name, price: a.price, quantity: a.quantity }))
-        : null,
+        : [],
     }));
 
     const { data: rpcData, error: rpcError } = await supabase.rpc(


### PR DESCRIPTION

🍰 Al pedir productos sin extras (ej: pasteles), el campo `addons` se enviaba como objeto vacío `{}` al RPC `create_order_with_items`, causando un error de tipo en la BD que esperaba un array JSONB.

✅ Se cambia el valor por defecto de `{}` a `[]` en checkoutService.ts para que la columna `addons` reciba siempre un array válido.